### PR TITLE
Types output - get 'runtime.connect' to return a 'runtime.Port'

### DIFF
--- a/src/generated/types.d.ts
+++ b/src/generated/types.d.ts
@@ -2,12 +2,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import sinon from 'sinon';
 
-export interface SinonEventStub {
-  addListener: sinon.SinonStub;
-  removeListener: sinon.SinonStub;
-  hasListener: sinon.SinonStub;
-}
-
 export interface BrowserMock {
   sinonSandbox: sinon.SinonSandbox;
   manifest: Manifest;
@@ -66,63 +60,208 @@ export interface BrowserMock {
   windows: Windows;
 }
 
-export interface Manifest {
-  KeyName: string[];
-  ProtocolHandler: {
-    name: string;
+export interface Manifest {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+export type ManifestKeyName = string;
+
+export type ManifestOptionalPermission = any;
+
+export type ManifestOptionalPermissionOrOrigin = any;
+
+export type ManifestPermission = any;
+
+export type ManifestPermissionOrOrigin = any;
+
+export type ManifestHttpURL = string;
+
+export type ManifestExtensionURL = string;
+
+export type ManifestExtensionFileUrl = string;
+
+export type ManifestImageDataOrExtensionURL = string;
+
+export type ManifestExtensionID = any;
+
+export type ManifestMatchPattern = any;
+
+export type ManifestMatchPatternRestricted = any;
+
+export type ManifestMatchPatternUnestricted = any;
+
+export type ManifestIconPath = any;
+
+export type ManifestIconImageData = any;
+
+export type ManifestUnrecognizedProperty = any;
+
+export type ManifestPersistentBackgroundProperty = any;
+
+export type ManifestNativeManifest = any;
+
+export type ManifestThemeColor = any;
+
+export interface ManifestProtocolHandler {
+  name: string;
+  protocol: any;
+  uriTemplate: any;
+}
+
+export interface ManifestManifestBase {
+  manifest_version: number;
+  applications?: {
+    gecko?: ManifestFirefoxSpecificProperties;
   };
-  ManifestBase: {
-    manifest_version: number;
-    name: string;
-    short_name?: string;
-    description?: string;
-    author?: string;
-    version: string;
-    homepage_url?: string;
+  browser_specific_settings?: {
+    gecko?: ManifestFirefoxSpecificProperties;
+    edge?: {};
   };
-  WebExtensionManifest: {
-    minimum_chrome_version?: string;
-    minimum_opera_version?: string;
-    incognito?: string;
-    content_security_policy?: string;
-    web_accessible_resources?: string[];
-    hidden?: boolean;
+  name: string;
+  short_name?: string;
+  description?: string;
+  author?: string;
+  version: string;
+  homepage_url?: string;
+}
+
+export interface ManifestWebExtensionManifest extends ManifestManifestBase {
+  minimum_chrome_version?: string;
+  minimum_opera_version?: string;
+  icons?: {};
+  incognito?: ManifestIncognito;
+  background?: any;
+  options_ui?: {
+    page: ManifestExtensionURL;
+    browser_style?: boolean;
+    chrome_style?: boolean;
+    open_in_tab?: boolean;
   };
-  WebExtensionLangpackManifest: {
-    homepage_url?: string;
-    langpack_id: string;
+  content_scripts?: ManifestContentScript[];
+  content_security_policy?: string;
+  permissions?: ManifestPermissionOrOrigin[];
+  optional_permissions?: ManifestOptionalPermissionOrOrigin[];
+  web_accessible_resources?: string[];
+  developer?: {
+    name?: string;
+    url?: string;
   };
-  WebExtensionDictionaryManifest: {
-    homepage_url?: string;
+  hidden?: boolean;
+}
+
+export type ManifestIncognito = 'not_allowed' | 'spanning';
+
+export interface ManifestWebExtensionLangpackManifest
+  extends ManifestManifestBase {
+  homepage_url?: string;
+  langpack_id: string;
+  languages: {};
+  sources?: {};
+}
+
+export interface ManifestWebExtensionDictionaryManifest
+  extends ManifestManifestBase {
+  homepage_url?: string;
+  dictionaries: {};
+}
+
+export interface ManifestThemeIcons {
+  light: ManifestExtensionURL;
+  dark: ManifestExtensionURL;
+  size: number;
+}
+
+export interface ManifestFirefoxSpecificProperties {
+  id?: ManifestExtensionID;
+  update_url?: string;
+  strict_min_version?: string;
+  strict_max_version?: string;
+}
+
+export interface ManifestContentScript {
+  matches: ManifestMatchPattern[];
+  exclude_matches?: ManifestMatchPattern[];
+  include_globs?: string[];
+  exclude_globs?: string[];
+  css?: ManifestExtensionURL[];
+  js?: ManifestExtensionURL[];
+  all_frames?: boolean;
+  match_about_blank?: boolean;
+  run_at?: ExtensionTypesRunAt;
+}
+
+export interface ManifestImageData extends ImageData {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+export interface ManifestThemeExperiment {
+  stylesheet?: ManifestExtensionURL;
+  images?: {};
+  colors?: {};
+  properties?: {};
+}
+
+export interface ManifestThemeType {
+  images?: {
+    additional_backgrounds?: ManifestImageDataOrExtensionURL[];
+    headerURL?: ManifestImageDataOrExtensionURL;
+    theme_frame?: ManifestImageDataOrExtensionURL;
   };
-  ThemeIcons: {
-    size: number;
+  colors?: {
+    tab_selected?: ManifestThemeColor;
+    accentcolor?: ManifestThemeColor;
+    frame?: ManifestThemeColor;
+    frame_inactive?: ManifestThemeColor;
+    textcolor?: ManifestThemeColor;
+    tab_background_text?: ManifestThemeColor;
+    tab_background_separator?: ManifestThemeColor;
+    tab_loading?: ManifestThemeColor;
+    tab_text?: ManifestThemeColor;
+    tab_line?: ManifestThemeColor;
+    toolbar?: ManifestThemeColor;
+    toolbar_text?: ManifestThemeColor;
+    bookmark_text?: ManifestThemeColor;
+    toolbar_field?: ManifestThemeColor;
+    toolbar_field_text?: ManifestThemeColor;
+    toolbar_field_border?: ManifestThemeColor;
+    toolbar_field_separator?: ManifestThemeColor;
+    toolbar_top_separator?: ManifestThemeColor;
+    toolbar_bottom_separator?: ManifestThemeColor;
+    toolbar_vertical_separator?: ManifestThemeColor;
+    icons?: ManifestThemeColor;
+    icons_attention?: ManifestThemeColor;
+    button_background_hover?: ManifestThemeColor;
+    button_background_active?: ManifestThemeColor;
+    popup?: ManifestThemeColor;
+    popup_text?: ManifestThemeColor;
+    popup_border?: ManifestThemeColor;
+    toolbar_field_focus?: ManifestThemeColor;
+    toolbar_field_text_focus?: ManifestThemeColor;
+    toolbar_field_border_focus?: ManifestThemeColor;
+    popup_highlight?: ManifestThemeColor;
+    popup_highlight_text?: ManifestThemeColor;
+    ntp_background?: ManifestThemeColor;
+    ntp_text?: ManifestThemeColor;
+    sidebar?: ManifestThemeColor;
+    sidebar_border?: ManifestThemeColor;
+    sidebar_text?: ManifestThemeColor;
+    sidebar_highlight?: ManifestThemeColor;
+    sidebar_highlight_text?: ManifestThemeColor;
+    toolbar_field_highlight?: ManifestThemeColor;
+    toolbar_field_highlight_text?: ManifestThemeColor;
   };
-  HttpURL: string[];
-  ExtensionURL: string[];
-  ExtensionFileUrl: string[];
-  ImageDataOrExtensionURL: string[];
-  FirefoxSpecificProperties: {
-    update_url?: string;
-    strict_min_version?: string;
-    strict_max_version?: string;
-  };
-  ContentScript: {
-    include_globs?: string[];
-    exclude_globs?: string[];
-    all_frames?: boolean;
-    match_about_blank?: boolean;
-  };
-  ImageData: {};
-  ThemeExperiment: {};
-  ThemeType: {};
-  ThemeManifest: {
-    default_locale?: string;
+  properties?: {
+    additional_backgrounds_alignment?: string[];
+    additional_backgrounds_tiling?: string[];
   };
 }
 
+export interface ManifestThemeManifest extends ManifestManifestBase {
+  theme: ManifestThemeType;
+  dark_theme?: ManifestThemeType;
+  default_locale?: string;
+  theme_experiment?: ManifestThemeExperiment;
+  icons?: {};
+}
+
 export interface ActivityLog {
-  onExtensionActivity: SinonEventStub;
+  onExtensionActivity: EventsEvent;
 }
 
 export interface Alarms {
@@ -131,10 +270,13 @@ export interface Alarms {
   getAll: sinon.SinonStub;
   clear: sinon.SinonStub;
   clearAll: sinon.SinonStub;
-  onAlarm: SinonEventStub;
-  Alarm: {
-    name: string;
-  };
+  onAlarm: EventsEvent;
+}
+
+export interface AlarmsAlarm {
+  name: string;
+  scheduledTime: number;
+  periodInMinutes?: number;
 }
 
 export interface Bookmarks {
@@ -151,33 +293,39 @@ export interface Bookmarks {
   removeTree: sinon.SinonStub;
   import?: sinon.SinonStub;
   export?: sinon.SinonStub;
-  onCreated: SinonEventStub;
-  onRemoved: SinonEventStub;
-  onChanged: SinonEventStub;
-  onMoved: SinonEventStub;
-  onChildrenReordered?: SinonEventStub;
-  onImportBegan?: SinonEventStub;
-  onImportEnded?: SinonEventStub;
-  BookmarkTreeNodeUnmodifiable: BookmarksBookmarkTreeNodeUnmodifiable[];
-  BookmarkTreeNodeType: BookmarksBookmarkTreeNodeType[];
-  BookmarkTreeNode: {
-    id: string;
-    parentId?: string;
-    index?: number;
-    url?: string;
-    title: string;
-  };
-  CreateDetails: {
-    parentId?: string;
-    index?: number;
-    title?: string;
-    url?: string;
-  };
+  onCreated: EventsEvent;
+  onRemoved: EventsEvent;
+  onChanged: EventsEvent;
+  onMoved: EventsEvent;
+  onChildrenReordered?: EventsEvent;
+  onImportBegan?: EventsEvent;
+  onImportEnded?: EventsEvent;
 }
 
 export type BookmarksBookmarkTreeNodeUnmodifiable = 'managed';
 
 export type BookmarksBookmarkTreeNodeType = 'bookmark' | 'folder' | 'separator';
+
+export interface BookmarksBookmarkTreeNode {
+  id: string;
+  parentId?: string;
+  index?: number;
+  url?: string;
+  title: string;
+  dateAdded?: number;
+  dateGroupModified?: number;
+  unmodifiable?: BookmarksBookmarkTreeNodeUnmodifiable;
+  type?: BookmarksBookmarkTreeNodeType;
+  children?: BookmarksBookmarkTreeNode[];
+}
+
+export interface BookmarksCreateDetails {
+  parentId?: string;
+  index?: number;
+  title?: string;
+  url?: string;
+  type?: BookmarksBookmarkTreeNodeType;
+}
 
 export interface BrowserAction {
   setTitle: sinon.SinonStub;
@@ -195,31 +343,35 @@ export interface BrowserAction {
   disable: sinon.SinonStub;
   isEnabled: sinon.SinonStub;
   openPopup: sinon.SinonStub;
-  onClicked: SinonEventStub;
-  Details: {
-    tabId?: number;
-    windowId?: number;
-  };
-  ImageDataType: {};
+  onClicked: EventsEvent;
 }
 
+export type BrowserActionColorArray = number[];
+
+export type BrowserActionColorValue = any;
+
+export interface BrowserActionDetails {
+  tabId?: number;
+  windowId?: number;
+}
+
+export interface BrowserActionImageDataType extends ImageData {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
 export interface BrowserSettings {
-  ImageAnimationBehavior: BrowserSettingsImageAnimationBehavior[];
-  ContextMenuMouseEvent: BrowserSettingsContextMenuMouseEvent[];
-  allowPopupsForUserEvents: Types['Setting'];
-  cacheEnabled: Types['Setting'];
-  closeTabsByDoubleClick: Types['Setting'];
-  contextMenuShowEvent: Types['Setting'];
-  homepageOverride: Types['Setting'];
-  imageAnimationBehavior: Types['Setting'];
-  newTabPageOverride: Types['Setting'];
-  newTabPosition: Types['Setting'];
-  openBookmarksInNewTabs: Types['Setting'];
-  openSearchResultsInNewTabs: Types['Setting'];
-  openUrlbarResultsInNewTabs: Types['Setting'];
-  webNotificationsDisabled: Types['Setting'];
-  overrideDocumentColors: Types['Setting'];
-  useDocumentFonts: Types['Setting'];
+  allowPopupsForUserEvents: TypesSetting;
+  cacheEnabled: TypesSetting;
+  closeTabsByDoubleClick: TypesSetting;
+  contextMenuShowEvent: TypesSetting;
+  homepageOverride: TypesSetting;
+  imageAnimationBehavior: TypesSetting;
+  newTabPageOverride: TypesSetting;
+  newTabPosition: TypesSetting;
+  openBookmarksInNewTabs: TypesSetting;
+  openSearchResultsInNewTabs: TypesSetting;
+  openUrlbarResultsInNewTabs: TypesSetting;
+  webNotificationsDisabled: TypesSetting;
+  overrideDocumentColors: TypesSetting;
+  useDocumentFonts: TypesSetting;
 }
 
 export type BrowserSettingsImageAnimationBehavior = 'normal' | 'none' | 'once';
@@ -241,29 +393,37 @@ export interface BrowsingData {
   removePluginData: sinon.SinonStub;
   removePasswords: sinon.SinonStub;
   removeWebSQL?: sinon.SinonStub;
-  RemovalOptions: {
-    hostnames?: string[];
+}
+
+export interface BrowsingDataRemovalOptions {
+  since?: ExtensionTypesDate;
+  hostnames?: string[];
+  originTypes?: {
+    unprotectedWeb?: boolean;
+    protectedWeb?: boolean;
+    extension?: boolean;
   };
-  DataTypeSet: {
-    cache?: boolean;
-    cookies?: boolean;
-    downloads?: boolean;
-    formData?: boolean;
-    history?: boolean;
-    indexedDB?: boolean;
-    localStorage?: boolean;
-    serverBoundCertificates?: boolean;
-    passwords?: boolean;
-    pluginData?: boolean;
-    serviceWorkers?: boolean;
-  };
+}
+
+export interface BrowsingDataDataTypeSet {
+  cache?: boolean;
+  cookies?: boolean;
+  downloads?: boolean;
+  formData?: boolean;
+  history?: boolean;
+  indexedDB?: boolean;
+  localStorage?: boolean;
+  serverBoundCertificates?: boolean;
+  passwords?: boolean;
+  pluginData?: boolean;
+  serviceWorkers?: boolean;
 }
 
 export interface CaptivePortal {
   getState: sinon.SinonStub;
   getLastChecked: sinon.SinonStub;
-  onStateChanged: SinonEventStub;
-  onConnectivityAvailable: SinonEventStub;
+  onStateChanged: EventsEvent;
+  onConnectivityAvailable: EventsEvent;
 }
 
 export interface Clipboard {
@@ -274,25 +434,33 @@ export interface Commands {
   update: sinon.SinonStub;
   reset: sinon.SinonStub;
   getAll: sinon.SinonStub;
-  onCommand: SinonEventStub;
-  Command: {
-    name?: string;
-    description?: string;
-    shortcut?: string;
-  };
+  onCommand: EventsEvent;
+}
+
+export interface CommandsCommand {
+  name?: string;
+  description?: string;
+  shortcut?: string;
 }
 
 export interface ContentScripts {
   register: sinon.SinonStub;
-  RegisteredContentScriptOptions: {
-    includeGlobs?: string[];
-    excludeGlobs?: string[];
-    allFrames?: boolean;
-    matchAboutBlank?: boolean;
-  };
-  RegisteredContentScript: {
-    unregister: sinon.SinonStub;
-  };
+}
+
+export interface ContentScriptsRegisteredContentScriptOptions {
+  matches: ManifestMatchPattern[];
+  excludeMatches?: ManifestMatchPattern[];
+  includeGlobs?: string[];
+  excludeGlobs?: string[];
+  css?: ExtensionTypesExtensionFileOrCode[];
+  js?: ExtensionTypesExtensionFileOrCode[];
+  allFrames?: boolean;
+  matchAboutBlank?: boolean;
+  runAt?: ExtensionTypesRunAt;
+}
+
+export interface ContentScriptsRegisteredContentScript {
+  unregister: sinon.SinonStub;
 }
 
 export interface ContextualIdentities {
@@ -301,17 +469,18 @@ export interface ContextualIdentities {
   create: sinon.SinonStub;
   update: sinon.SinonStub;
   remove: sinon.SinonStub;
-  onUpdated: SinonEventStub;
-  onCreated: SinonEventStub;
-  onRemoved: SinonEventStub;
-  ContextualIdentity: {
-    name: string;
-    icon: string;
-    iconUrl: string;
-    color: string;
-    colorCode: string;
-    cookieStoreId: string;
-  };
+  onUpdated: EventsEvent;
+  onCreated: EventsEvent;
+  onRemoved: EventsEvent;
+}
+
+export interface ContextualIdentitiesContextualIdentity {
+  name: string;
+  icon: string;
+  iconUrl: string;
+  color: string;
+  colorCode: string;
+  cookieStoreId: string;
 }
 
 export interface Cookies {
@@ -320,25 +489,7 @@ export interface Cookies {
   set: sinon.SinonStub;
   remove: sinon.SinonStub;
   getAllCookieStores: sinon.SinonStub;
-  onChanged: SinonEventStub;
-  SameSiteStatus: CookiesSameSiteStatus[];
-  Cookie: {
-    name: string;
-    value: string;
-    domain: string;
-    hostOnly: boolean;
-    path: string;
-    secure: boolean;
-    httpOnly: boolean;
-    session: boolean;
-    storeId: string;
-    firstPartyDomain: string;
-  };
-  CookieStore: {
-    id: string;
-    incognito: boolean;
-  };
-  OnChangedCause: CookiesOnChangedCause[];
+  onChanged: EventsEvent;
 }
 
 export type CookiesSameSiteStatus = 'no_restriction' | 'lax' | 'strict';
@@ -349,6 +500,27 @@ export type CookiesOnChangedCause =
   | 'explicit'
   | 'expired_overwrite'
   | 'overwrite';
+
+export interface CookiesCookie {
+  name: string;
+  value: string;
+  domain: string;
+  hostOnly: boolean;
+  path: string;
+  secure: boolean;
+  httpOnly: boolean;
+  sameSite: CookiesSameSiteStatus;
+  session: boolean;
+  expirationDate?: number;
+  storeId: string;
+  firstPartyDomain: string;
+}
+
+export interface CookiesCookieStore {
+  id: string;
+  tabIds: number[];
+  incognito: boolean;
+}
 
 export interface Devtools {
   inspectedWindow: DevtoolsInspectedWindow;
@@ -361,67 +533,78 @@ export interface DevtoolsInspectedWindow {
   eval: sinon.SinonStub;
   reload: sinon.SinonStub;
   getResources?: sinon.SinonStub;
-  onResourceAdded?: SinonEventStub;
-  onResourceContentCommitted?: SinonEventStub;
-  Resource: {
-    getContent?: sinon.SinonStub;
-    setContent?: sinon.SinonStub;
-    url: string;
-  };
+  onResourceAdded?: EventsEvent;
+  onResourceContentCommitted?: EventsEvent;
+  tabId: number;
+}
+
+export interface DevtoolsResource {
+  getContent?: sinon.SinonStub;
+  setContent?: sinon.SinonStub;
+  url: string;
 }
 
 export interface DevtoolsNetwork {
   getHAR: sinon.SinonStub;
-  onRequestFinished: SinonEventStub;
-  onNavigated: SinonEventStub;
-  Request: {
-    getContent: sinon.SinonStub;
-  };
+  onRequestFinished: EventsEvent;
+  onNavigated: EventsEvent;
+}
+
+export interface DevtoolsRequest {
+  getContent: sinon.SinonStub;
 }
 
 export interface DevtoolsPanels {
   create: sinon.SinonStub;
   setOpenResourceHandler?: sinon.SinonStub;
   openResource?: sinon.SinonStub;
-  onThemeChanged: SinonEventStub;
-  ElementsPanel: {
-    createSidebarPane: sinon.SinonStub;
-    onSelectionChanged: SinonEventStub;
-  };
-  SourcesPanel: {
-    createSidebarPane?: sinon.SinonStub;
-    onSelectionChanged?: SinonEventStub;
-  };
-  ExtensionPanel: {
-    createStatusBarButton?: sinon.SinonStub;
-    onSearch?: SinonEventStub;
-    onShown: SinonEventStub;
-    onHidden: SinonEventStub;
-  };
-  ExtensionSidebarPane: {
-    setHeight?: sinon.SinonStub;
-    setExpression: sinon.SinonStub;
-    setObject: sinon.SinonStub;
-    setPage: sinon.SinonStub;
-    onShown: SinonEventStub;
-    onHidden: SinonEventStub;
-  };
-  Button: {
-    update?: sinon.SinonStub;
-    onClicked?: SinonEventStub;
-  };
-  elements: DevtoolsPanels['ElementsPanel'];
-  sources: DevtoolsPanels['SourcesPanel'];
-  themeName: string[];
+  onThemeChanged: EventsEvent;
+  elements: DevtoolsElementsPanel;
+  sources: DevtoolsSourcesPanel;
+  themeName: string;
+}
+
+export interface DevtoolsElementsPanel {
+  createSidebarPane: sinon.SinonStub;
+  onSelectionChanged: EventsEvent;
+}
+
+export interface DevtoolsSourcesPanel {
+  createSidebarPane?: sinon.SinonStub;
+  onSelectionChanged?: EventsEvent;
+}
+
+export interface DevtoolsExtensionPanel {
+  createStatusBarButton?: () => DevtoolsButton;
+  onSearch?: EventsEvent;
+  onShown: EventsEvent;
+  onHidden: EventsEvent;
+}
+
+export interface DevtoolsExtensionSidebarPane {
+  setHeight?: sinon.SinonStub;
+  setExpression: sinon.SinonStub;
+  setObject: sinon.SinonStub;
+  setPage: sinon.SinonStub;
+  onShown: EventsEvent;
+  onHidden: EventsEvent;
+}
+
+export interface DevtoolsButton {
+  update?: sinon.SinonStub;
+  onClicked?: EventsEvent;
 }
 
 export interface Dns {
   resolve: sinon.SinonStub;
-  DNSRecord: {
-    canonicalName?: string;
-    isTRR: string;
-    addresses: string[];
-  };
+}
+
+export type DnsResolveFlags = string[];
+
+export interface DnsDNSRecord {
+  canonicalName?: string;
+  isTRR: string;
+  addresses: string[];
 }
 
 export interface Downloads {
@@ -439,53 +622,9 @@ export interface Downloads {
   acceptDanger?: sinon.SinonStub;
   drag?: sinon.SinonStub;
   setShelfEnabled?: sinon.SinonStub;
-  onCreated: SinonEventStub;
-  onErased: SinonEventStub;
-  onChanged: SinonEventStub;
-  FilenameConflictAction: DownloadsFilenameConflictAction[];
-  InterruptReason: DownloadsInterruptReason[];
-  DangerType: DownloadsDangerType[];
-  State: DownloadsState[];
-  DownloadItem: {
-    id: number;
-    url: string;
-    referrer?: string;
-    filename: string;
-    incognito: boolean;
-    mime?: string;
-    startTime: string;
-    endTime?: string;
-    estimatedEndTime?: string;
-    paused: boolean;
-    canResume: boolean;
-    exists: boolean;
-    byExtensionId?: string;
-    byExtensionName?: string;
-  };
-  StringDelta: {
-    current?: string;
-    previous?: string;
-  };
-  DoubleDelta: {};
-  BooleanDelta: {
-    current?: boolean;
-    previous?: boolean;
-  };
-  DownloadQuery: {
-    query?: string[];
-    filenameRegex?: string;
-    urlRegex?: string;
-    limit?: number;
-    orderBy?: string[];
-    id?: number;
-    url?: string;
-    filename?: string;
-    mime?: string;
-    startTime?: string;
-    endTime?: string;
-    paused?: boolean;
-    exists?: boolean;
-  };
+  onCreated: EventsEvent;
+  onErased: EventsEvent;
+  onChanged: EventsEvent;
 }
 
 export type DownloadsFilenameConflictAction =
@@ -531,51 +670,126 @@ export type DownloadsDangerType =
 
 export type DownloadsState = 'in_progress' | 'interrupted' | 'complete';
 
-export interface Events {
-  Rule: {
-    id?: string;
-    tags?: string[];
-    priority?: number;
-  };
-  Event: {
-    addListener: sinon.SinonStub;
-    removeListener: sinon.SinonStub;
-    hasListener: sinon.SinonStub;
-    hasListeners: sinon.SinonStub;
-    addRules?: sinon.SinonStub;
-    getRules?: sinon.SinonStub;
-    removeRules?: sinon.SinonStub;
-  };
-  UrlFilter: {
-    hostContains?: string;
-    hostEquals?: string;
-    hostPrefix?: string;
-    hostSuffix?: string;
-    pathContains?: string;
-    pathEquals?: string;
-    pathPrefix?: string;
-    pathSuffix?: string;
-    queryContains?: string;
-    queryEquals?: string;
-    queryPrefix?: string;
-    querySuffix?: string;
-    urlContains?: string;
-    urlEquals?: string;
-    urlMatches?: string;
-    originAndPathMatches?: string;
-    urlPrefix?: string;
-    urlSuffix?: string;
-    schemes?: string[];
-  };
+export type DownloadsDownloadTime = any;
+
+export interface DownloadsDownloadItem {
+  id: number;
+  url: string;
+  referrer?: string;
+  filename: string;
+  incognito: boolean;
+  danger: DownloadsDangerType;
+  mime?: string;
+  startTime: string;
+  endTime?: string;
+  estimatedEndTime?: string;
+  state: DownloadsState;
+  paused: boolean;
+  canResume: boolean;
+  error?: DownloadsInterruptReason;
+  bytesReceived: number;
+  totalBytes: number;
+  fileSize: number;
+  exists: boolean;
+  byExtensionId?: string;
+  byExtensionName?: string;
 }
 
-export interface Experiments {
-  ExperimentAPI: {};
-  ExperimentURL: string[];
-  APIEvent: ExperimentsAPIEvent[];
-  APIParentScope: ExperimentsAPIParentScope[];
-  APIChildScope: ExperimentsAPIChildScope[];
+export interface DownloadsStringDelta {
+  current?: string;
+  previous?: string;
 }
+
+export interface DownloadsDoubleDelta {
+  current?: number;
+  previous?: number;
+}
+
+export interface DownloadsBooleanDelta {
+  current?: boolean;
+  previous?: boolean;
+}
+
+export interface DownloadsDownloadQuery {
+  query?: string[];
+  startedBefore?: DownloadsDownloadTime;
+  startedAfter?: DownloadsDownloadTime;
+  endedBefore?: DownloadsDownloadTime;
+  endedAfter?: DownloadsDownloadTime;
+  totalBytesGreater?: number;
+  totalBytesLess?: number;
+  filenameRegex?: string;
+  urlRegex?: string;
+  limit?: number;
+  orderBy?: string[];
+  id?: number;
+  url?: string;
+  filename?: string;
+  danger?: DownloadsDangerType;
+  mime?: string;
+  startTime?: string;
+  endTime?: string;
+  state?: DownloadsState;
+  paused?: boolean;
+  error?: DownloadsInterruptReason;
+  bytesReceived?: number;
+  totalBytes?: number;
+  fileSize?: number;
+  exists?: boolean;
+}
+
+export interface Events {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+export interface EventsRule {
+  id?: string;
+  tags?: string[];
+  conditions: any[];
+  actions: any[];
+  priority?: number;
+}
+
+export interface EventsEvent {
+  addListener: sinon.SinonStub;
+  removeListener: sinon.SinonStub;
+  hasListener: sinon.SinonStub;
+  hasListeners: sinon.SinonStub;
+  addRules?: sinon.SinonStub;
+  getRules?: sinon.SinonStub;
+  removeRules?: sinon.SinonStub;
+}
+
+export interface EventsUrlFilter {
+  hostContains?: string;
+  hostEquals?: string;
+  hostPrefix?: string;
+  hostSuffix?: string;
+  pathContains?: string;
+  pathEquals?: string;
+  pathPrefix?: string;
+  pathSuffix?: string;
+  queryContains?: string;
+  queryEquals?: string;
+  queryPrefix?: string;
+  querySuffix?: string;
+  urlContains?: string;
+  urlEquals?: string;
+  urlMatches?: string;
+  originAndPathMatches?: string;
+  urlPrefix?: string;
+  urlSuffix?: string;
+  schemes?: string[];
+  ports?: any[];
+}
+
+export interface Experiments {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+export type ExperimentsExperimentURL = string;
+
+export type ExperimentsAPIPaths = ExperimentsAPIPath[];
+
+export type ExperimentsAPIPath = string[];
+
+export type ExperimentsAPIEvents = ExperimentsAPIEvent[];
 
 export type ExperimentsAPIEvent = 'startup';
 
@@ -589,6 +803,21 @@ export type ExperimentsAPIChildScope =
   | 'content_child'
   | 'devtools_child';
 
+export interface ExperimentsExperimentAPI {
+  schema: ExperimentsExperimentURL;
+  parent?: {
+    events?: ExperimentsAPIEvents;
+    paths?: ExperimentsAPIPaths;
+    script: ExperimentsExperimentURL;
+    scopes?: ExperimentsAPIParentScope[];
+  };
+  child?: {
+    paths: ExperimentsAPIPaths;
+    script: ExperimentsExperimentURL;
+    scopes: ExperimentsAPIChildScope[];
+  };
+}
+
 export interface Extension {
   getURL: sinon.SinonStub;
   getViews: sinon.SinonStub;
@@ -596,31 +825,17 @@ export interface Extension {
   isAllowedIncognitoAccess: sinon.SinonStub;
   isAllowedFileSchemeAccess: sinon.SinonStub;
   setUpdateUrlData?: sinon.SinonStub;
-  onRequest?: SinonEventStub;
-  onRequestExternal?: SinonEventStub;
-  ViewType: ExtensionViewType[];
-  lastError: {
+  onRequest?: EventsEvent;
+  onRequestExternal?: EventsEvent;
+  lastError?: {
     message: string;
   };
+  inIncognitoContext?: boolean;
 }
 
 export type ExtensionViewType = 'tab' | 'popup' | 'sidebar';
 
-export interface ExtensionTypes {
-  ImageFormat: ExtensionTypesImageFormat[];
-  ImageDetails: {
-    quality?: number;
-  };
-  RunAt: ExtensionTypesRunAt[];
-  CSSOrigin: ExtensionTypesCSSOrigin[];
-  InjectDetails: {
-    code?: string;
-    file?: string;
-    allFrames?: boolean;
-    matchAboutBlank?: boolean;
-    frameId?: number;
-  };
-}
+export interface ExtensionTypes {} // eslint-disable-line @typescript-eslint/no-empty-interface
 
 export type ExtensionTypesImageFormat = 'jpeg' | 'png';
 
@@ -630,6 +845,27 @@ export type ExtensionTypesRunAt =
   | 'document_idle';
 
 export type ExtensionTypesCSSOrigin = 'user' | 'author';
+
+export type ExtensionTypesDate = any;
+
+export type ExtensionTypesExtensionFileOrCode = any;
+
+export type ExtensionTypesPlainJSONValue = any;
+
+export interface ExtensionTypesImageDetails {
+  format?: ExtensionTypesImageFormat;
+  quality?: number;
+}
+
+export interface ExtensionTypesInjectDetails {
+  code?: string;
+  file?: string;
+  allFrames?: boolean;
+  matchAboutBlank?: boolean;
+  frameId?: number;
+  runAt?: ExtensionTypesRunAt;
+  cssOrigin?: ExtensionTypesCSSOrigin;
+}
 
 export interface Find {
   find: sinon.SinonStub;
@@ -647,9 +883,7 @@ export interface GeckoProfiler {
   getProfileAsArrayBuffer: sinon.SinonStub;
   getProfileAsGzippedArrayBuffer: sinon.SinonStub;
   getSymbols: sinon.SinonStub;
-  onRunning: SinonEventStub;
-  ProfilerFeature: GeckoProfilerProfilerFeature[];
-  supports: GeckoProfilerSupports[];
+  onRunning: EventsEvent;
 }
 
 export type GeckoProfilerProfilerFeature =
@@ -678,22 +912,9 @@ export interface History {
   deleteUrl: sinon.SinonStub;
   deleteRange: sinon.SinonStub;
   deleteAll: sinon.SinonStub;
-  onVisited: SinonEventStub;
-  onVisitRemoved: SinonEventStub;
-  onTitleChanged: SinonEventStub;
-  TransitionType: HistoryTransitionType[];
-  HistoryItem: {
-    id: string;
-    url?: string;
-    title?: string;
-    visitCount?: number;
-    typedCount?: number;
-  };
-  VisitItem: {
-    id: string;
-    visitId: string;
-    referringVisitId: string;
-  };
+  onVisited: EventsEvent;
+  onVisitRemoved: EventsEvent;
+  onTitleChanged: EventsEvent;
 }
 
 export type HistoryTransitionType =
@@ -709,13 +930,31 @@ export type HistoryTransitionType =
   | 'keyword'
   | 'keyword_generated';
 
+export interface HistoryHistoryItem {
+  id: string;
+  url?: string;
+  title?: string;
+  lastVisitTime?: number;
+  visitCount?: number;
+  typedCount?: number;
+}
+
+export interface HistoryVisitItem {
+  id: string;
+  visitId: string;
+  visitTime?: number;
+  referringVisitId: string;
+  transition: HistoryTransitionType;
+}
+
 export interface I18n {
   getAcceptLanguages: sinon.SinonStub;
   getMessage: sinon.SinonStub;
   getUILanguage: sinon.SinonStub;
   detectLanguage: sinon.SinonStub;
-  LanguageCode: string[];
 }
+
+export type I18nLanguageCode = string;
 
 export interface Identity {
   getAccounts?: sinon.SinonStub;
@@ -724,17 +963,17 @@ export interface Identity {
   removeCachedAuthToken?: sinon.SinonStub;
   launchWebAuthFlow: sinon.SinonStub;
   getRedirectURL: sinon.SinonStub;
-  onSignInChanged?: SinonEventStub;
-  AccountInfo: {
-    id: string;
-  };
+  onSignInChanged?: EventsEvent;
+}
+
+export interface IdentityAccountInfo {
+  id: string;
 }
 
 export interface Idle {
   queryState: sinon.SinonStub;
   setDetectionInterval: sinon.SinonStub;
-  onStateChanged: SinonEventStub;
-  IdleState: IdleIdleState[];
+  onStateChanged: EventsEvent;
 }
 
 export type IdleIdleState = 'active' | 'idle';
@@ -746,32 +985,10 @@ export interface Management {
   getSelf: sinon.SinonStub;
   uninstallSelf: sinon.SinonStub;
   setEnabled: sinon.SinonStub;
-  onDisabled: SinonEventStub;
-  onEnabled: SinonEventStub;
-  onInstalled: SinonEventStub;
-  onUninstalled: SinonEventStub;
-  IconInfo: {
-    size: number;
-    url: string;
-  };
-  ExtensionDisabledReason: ManagementExtensionDisabledReason[];
-  ExtensionType: ManagementExtensionType[];
-  ExtensionInstallType: ManagementExtensionInstallType[];
-  ExtensionInfo: {
-    id: string;
-    name: string;
-    shortName?: string;
-    description: string;
-    version: string;
-    versionName?: string;
-    mayDisable: boolean;
-    enabled: boolean;
-    homepageUrl?: string;
-    updateUrl?: string;
-    optionsUrl: string;
-    permissions?: string[];
-    hostPermissions?: string[];
-  };
+  onDisabled: EventsEvent;
+  onEnabled: EventsEvent;
+  onInstalled: EventsEvent;
+  onUninstalled: EventsEvent;
 }
 
 export type ManagementExtensionDisabledReason =
@@ -786,6 +1003,50 @@ export type ManagementExtensionInstallType =
   | 'sideload'
   | 'other';
 
+export interface ManagementIconInfo {
+  size: number;
+  url: string;
+}
+
+export interface ManagementExtensionInfo {
+  id: string;
+  name: string;
+  shortName?: string;
+  description: string;
+  version: string;
+  versionName?: string;
+  mayDisable: boolean;
+  enabled: boolean;
+  disabledReason?: ManagementExtensionDisabledReason;
+  type: ManagementExtensionType;
+  homepageUrl?: string;
+  updateUrl?: string;
+  optionsUrl: string;
+  icons?: ManagementIconInfo[];
+  permissions?: string[];
+  hostPermissions?: string[];
+  installType: ManagementExtensionInstallType;
+}
+
+export interface ContextMenus extends Menus {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
+export type ContextMenusContextType =
+  | 'all'
+  | 'page'
+  | 'frame'
+  | 'selection'
+  | 'link'
+  | 'editable'
+  | 'password'
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'launcher'
+  | 'bookmark'
+  | 'browser_action'
+  | 'page_action'
+  | 'tab';
+
 export interface Menus {
   create: sinon.SinonStub;
   update: sinon.SinonStub;
@@ -793,28 +1054,9 @@ export interface Menus {
   removeAll: sinon.SinonStub;
   overrideContext: sinon.SinonStub;
   refresh: sinon.SinonStub;
-  onClicked: SinonEventStub;
-  onShown: SinonEventStub;
-  onHidden: SinonEventStub;
-  ContextType: MenusContextType[];
-  ItemType: MenusItemType[];
-  OnClickData: {
-    mediaType?: string;
-    linkText?: string;
-    linkUrl?: string;
-    srcUrl?: string;
-    pageUrl?: string;
-    frameId?: number;
-    frameUrl?: string;
-    selectionText?: string;
-    editable: boolean;
-    wasChecked?: boolean;
-    checked?: boolean;
-    bookmarkId: string;
-    modifiers: MenusModifiers[];
-    button?: number;
-    targetElementId?: number;
-  };
+  onClicked: EventsEvent;
+  onShown: EventsEvent;
+  onHidden: EventsEvent;
   ACTION_MENU_TOP_LEVEL_LIMIT: 6;
   getTargetElement: sinon.SinonStub;
 }
@@ -839,37 +1081,72 @@ export type MenusContextType =
 
 export type MenusItemType = 'normal' | 'checkbox' | 'radio' | 'separator';
 
-export type MenusModifiers = 'Shift' | 'Alt' | 'Command' | 'Ctrl' | 'MacCtrl';
+export interface MenusOnClickData {
+  menuItemId: any;
+  parentMenuItemId?: any;
+  viewType?: ExtensionViewType;
+  mediaType?: string;
+  linkText?: string;
+  linkUrl?: string;
+  srcUrl?: string;
+  pageUrl?: string;
+  frameId?: number;
+  frameUrl?: string;
+  selectionText?: string;
+  editable: boolean;
+  wasChecked?: boolean;
+  checked?: boolean;
+  bookmarkId: string;
+  modifiers: string[];
+  button?: number;
+  targetElementId?: number;
+}
 
 export interface NetworkStatus {
   getLinkInfo: sinon.SinonStub;
-  onConnectionChanged: SinonEventStub;
-  NetworkLinkInfo: {
-    status: string;
-    type: string;
-    id?: string;
-  };
+  onConnectionChanged: EventsEvent;
 }
+
+export interface NetworkStatusNetworkLinkInfo {
+  status: NetworkStatusStatus;
+  type: NetworkStatusType;
+  id?: string;
+}
+
+export type NetworkStatusStatus = 'unknown' | 'up' | 'down';
+
+export type NetworkStatusType =
+  | 'unknown'
+  | 'ethernet'
+  | 'usb'
+  | 'wifi'
+  | 'wimax'
+  | '2g'
+  | '3g'
+  | '4g';
 
 export interface NormandyAddonStudy {
   getStudy: sinon.SinonStub;
   endStudy: sinon.SinonStub;
   getClientMetadata: sinon.SinonStub;
-  onUnenroll: SinonEventStub;
-  Study: {
-    recipeId: number;
-    slug: string;
-    userFacingName: string;
-    userFacingDescription: string;
-    branch: string;
-    active: boolean;
-    addonId: string;
-    addonUrl: string;
-    addonVersion: string;
-    extensionApiId: number;
-    extensionHash: string;
-    extensionHashAlgorithm: string;
-  };
+  onUnenroll: EventsEvent;
+}
+
+export interface NormandyAddonStudyStudy {
+  recipeId: number;
+  slug: string;
+  userFacingName: string;
+  userFacingDescription: string;
+  branch: string;
+  active: boolean;
+  addonId: string;
+  addonUrl: string;
+  addonVersion: string;
+  studyStartDate: ExtensionTypesDate;
+  studyEndDate: ExtensionTypesDate;
+  extensionApiId: number;
+  extensionHash: string;
+  extensionHashAlgorithm: string;
 }
 
 export interface Notifications {
@@ -878,61 +1155,67 @@ export interface Notifications {
   clear: sinon.SinonStub;
   getAll: sinon.SinonStub;
   getPermissionLevel?: sinon.SinonStub;
-  onClosed: SinonEventStub;
-  onClicked: SinonEventStub;
-  onButtonClicked: SinonEventStub;
-  onPermissionLevelChanged?: SinonEventStub;
-  onShowSettings?: SinonEventStub;
-  onShown: SinonEventStub;
-  TemplateType: NotificationsTemplateType[];
-  PermissionLevel: NotificationsPermissionLevel[];
-  NotificationItem: {
-    title: string;
-    message: string;
-  };
-  CreateNotificationOptions: {
-    iconUrl?: string;
-    appIconMaskUrl?: string;
-    title: string;
-    message: string;
-    contextMessage?: string;
-    priority?: number;
-    imageUrl?: string;
-    progress?: number;
-    isClickable?: boolean;
-  };
-  UpdateNotificationOptions: {
-    iconUrl?: string;
-    appIconMaskUrl?: string;
-    title?: string;
-    message?: string;
-    contextMessage?: string;
-    priority?: number;
-    imageUrl?: string;
-    progress?: number;
-    isClickable?: boolean;
-  };
+  onClosed: EventsEvent;
+  onClicked: EventsEvent;
+  onButtonClicked: EventsEvent;
+  onPermissionLevelChanged?: EventsEvent;
+  onShowSettings?: EventsEvent;
+  onShown: EventsEvent;
 }
 
 export type NotificationsTemplateType = 'basic' | 'image' | 'list' | 'progress';
 
 export type NotificationsPermissionLevel = 'granted' | 'denied';
 
+export interface NotificationsNotificationItem {
+  title: string;
+  message: string;
+}
+
+export interface NotificationsCreateNotificationOptions {
+  type: NotificationsTemplateType;
+  iconUrl?: string;
+  appIconMaskUrl?: string;
+  title: string;
+  message: string;
+  contextMessage?: string;
+  priority?: number;
+  eventTime?: number;
+  buttons?: {
+    title: string;
+    iconUrl?: string;
+  }[];
+  imageUrl?: string;
+  items?: NotificationsNotificationItem[];
+  progress?: number;
+  isClickable?: boolean;
+}
+
+export interface NotificationsUpdateNotificationOptions {
+  type?: NotificationsTemplateType;
+  iconUrl?: string;
+  appIconMaskUrl?: string;
+  title?: string;
+  message?: string;
+  contextMessage?: string;
+  priority?: number;
+  eventTime?: number;
+  buttons?: {
+    title: string;
+    iconUrl?: string;
+  }[];
+  imageUrl?: string;
+  items?: NotificationsNotificationItem[];
+  progress?: number;
+  isClickable?: boolean;
+}
+
 export interface Omnibox {
   setDefaultSuggestion: sinon.SinonStub;
-  onInputStarted: SinonEventStub;
-  onInputChanged: SinonEventStub;
-  onInputEntered: SinonEventStub;
-  onInputCancelled: SinonEventStub;
-  DescriptionStyleType: OmniboxDescriptionStyleType[];
-  OnInputEnteredDisposition: OmniboxOnInputEnteredDisposition[];
-  SuggestResult: {
-    content: string;
-    description: string;
-  };
-  DefaultSuggestResult: {
-    description: string;
-  };
+  onInputStarted: EventsEvent;
+  onInputChanged: EventsEvent;
+  onInputEntered: EventsEvent;
+  onInputCancelled: EventsEvent;
 }
 
 export type OmniboxDescriptionStyleType = 'url' | 'match' | 'dim';
@@ -941,6 +1224,33 @@ export type OmniboxOnInputEnteredDisposition =
   | 'currentTab'
   | 'newForegroundTab'
   | 'newBackgroundTab';
+
+export interface OmniboxSuggestResult {
+  content: string;
+  description: string;
+  descriptionStyles?: {
+    offset: number;
+    type: OmniboxDescriptionStyleType;
+    length?: number;
+  }[];
+  descriptionStylesRaw?: {
+    offset: number;
+    type: number;
+  }[];
+}
+
+export interface OmniboxDefaultSuggestResult {
+  description: string;
+  descriptionStyles?: {
+    offset: number;
+    type: OmniboxDescriptionStyleType;
+    length?: number;
+  }[];
+  descriptionStylesRaw?: {
+    offset: number;
+    type: number;
+  }[];
+}
 
 export interface PageAction {
   show: sinon.SinonStub;
@@ -952,19 +1262,28 @@ export interface PageAction {
   setPopup: sinon.SinonStub;
   getPopup: sinon.SinonStub;
   openPopup: sinon.SinonStub;
-  onClicked: SinonEventStub;
-  ImageDataType: {};
+  onClicked: EventsEvent;
 }
+
+export interface PageActionImageDataType extends ImageData {} // eslint-disable-line @typescript-eslint/no-empty-interface
 
 export interface Permissions {
   getAll: sinon.SinonStub;
   contains: sinon.SinonStub;
   request: sinon.SinonStub;
   remove: sinon.SinonStub;
-  onAdded?: SinonEventStub;
-  onRemoved?: SinonEventStub;
-  Permissions: {};
-  AnyPermissions: {};
+  onAdded?: EventsEvent;
+  onRemoved?: EventsEvent;
+}
+
+export interface PermissionsPermissions {
+  permissions?: ManifestOptionalPermission[];
+  origins?: ManifestMatchPattern[];
+}
+
+export interface PermissionsAnyPermissions {
+  permissions?: ManifestPermission[];
+  origins?: ManifestMatchPattern[];
 }
 
 export interface Pkcs11 {
@@ -981,13 +1300,12 @@ export interface Privacy {
 }
 
 export interface PrivacyNetwork {
-  IPHandlingPolicy: PrivacyNetworkIPHandlingPolicy[];
-  networkPredictionEnabled: Types['Setting'];
-  peerConnectionEnabled: Types['Setting'];
-  webRTCIPHandlingPolicy: Types['Setting'];
+  networkPredictionEnabled: TypesSetting;
+  peerConnectionEnabled: TypesSetting;
+  webRTCIPHandlingPolicy: TypesSetting;
 }
 
-export type PrivacyNetworkIPHandlingPolicy =
+export type PrivacyIPHandlingPolicy =
   | 'default'
   | 'default_public_and_private_interfaces'
   | 'default_public_interface_only'
@@ -995,52 +1313,67 @@ export type PrivacyNetworkIPHandlingPolicy =
   | 'proxy_only';
 
 export interface PrivacyServices {
-  passwordSavingEnabled: Types['Setting'];
+  passwordSavingEnabled: TypesSetting;
 }
 
 export interface PrivacyWebsites {
-  TrackingProtectionModeOption: PrivacyWebsitesTrackingProtectionModeOption[];
-  CookieConfig: {
-    behavior?: string;
-    nonPersistentCookies?: boolean;
-  };
-  thirdPartyCookiesAllowed: Types['Setting'];
-  hyperlinkAuditingEnabled: Types['Setting'];
-  referrersEnabled: Types['Setting'];
-  resistFingerprinting: Types['Setting'];
-  firstPartyIsolate: Types['Setting'];
-  protectedContentEnabled: Types['Setting'];
-  trackingProtectionMode: Types['Setting'];
-  cookieConfig: Types['Setting'];
+  thirdPartyCookiesAllowed?: TypesSetting;
+  hyperlinkAuditingEnabled: TypesSetting;
+  referrersEnabled: TypesSetting;
+  resistFingerprinting: TypesSetting;
+  firstPartyIsolate: TypesSetting;
+  protectedContentEnabled?: TypesSetting;
+  trackingProtectionMode: TypesSetting;
+  cookieConfig: TypesSetting;
 }
 
-export type PrivacyWebsitesTrackingProtectionModeOption =
+export type PrivacyTrackingProtectionModeOption =
   | 'always'
   | 'never'
   | 'private_browsing';
+
+export interface PrivacyCookieConfig {
+  behavior?: PrivacyBehavior;
+  nonPersistentCookies?: boolean;
+}
+
+export type PrivacyBehavior =
+  | 'allow_all'
+  | 'reject_all'
+  | 'reject_third_party'
+  | 'allow_visited'
+  | 'reject_trackers';
 
 export interface Proxy {
   register: sinon.SinonStub;
   unregister: sinon.SinonStub;
   registerProxyScript: sinon.SinonStub;
-  onRequest: SinonEventStub;
-  onError: SinonEventStub;
-  onProxyError: SinonEventStub;
-  ProxyConfig: {
-    proxyType?: string;
-    http?: string;
-    httpProxyAll?: boolean;
-    ftp?: string;
-    ssl?: string;
-    socks?: string;
-    socksVersion?: number;
-    passthrough?: string;
-    autoConfigUrl?: string;
-    autoLogin?: boolean;
-    proxyDNS?: boolean;
-  };
-  settings: Types['Setting'];
+  onRequest: EventsEvent;
+  onError: EventsEvent;
+  onProxyError: EventsEvent;
+  settings: TypesSetting;
 }
+
+export interface ProxyProxyConfig {
+  proxyType?: ProxyProxyType;
+  http?: string;
+  httpProxyAll?: boolean;
+  ftp?: string;
+  ssl?: string;
+  socks?: string;
+  socksVersion?: number;
+  passthrough?: string;
+  autoConfigUrl?: string;
+  autoLogin?: boolean;
+  proxyDNS?: boolean;
+}
+
+export type ProxyProxyType =
+  | 'none'
+  | 'autoDetect'
+  | 'system'
+  | 'manual'
+  | 'autoConfig';
 
 export interface Runtime {
   getBackgroundPage: sinon.SinonStub;
@@ -1051,49 +1384,28 @@ export interface Runtime {
   reload: sinon.SinonStub;
   requestUpdateCheck?: sinon.SinonStub;
   restart?: sinon.SinonStub;
-  connect: sinon.SinonStub;
-  connectNative: sinon.SinonStub;
+  connect: () => RuntimePort;
+  connectNative: () => RuntimePort;
   sendMessage: sinon.SinonStub;
   sendNativeMessage: sinon.SinonStub;
   getBrowserInfo: sinon.SinonStub;
   getPlatformInfo: sinon.SinonStub;
   getPackageDirectoryEntry?: sinon.SinonStub;
-  onStartup: SinonEventStub;
-  onInstalled: SinonEventStub;
-  onSuspend?: SinonEventStub;
-  onSuspendCanceled?: SinonEventStub;
-  onUpdateAvailable: SinonEventStub;
-  onBrowserUpdateAvailable?: SinonEventStub;
-  onConnect: SinonEventStub;
-  onConnectExternal: SinonEventStub;
-  onMessage: SinonEventStub;
-  onMessageExternal: SinonEventStub;
-  onRestartRequired?: SinonEventStub;
-  Port: {
-    name: string;
-  };
-  MessageSender: {
-    frameId?: number;
-    id?: string;
-    url?: string;
-    tlsChannelId?: string;
-  };
-  PlatformOs: RuntimePlatformOs[];
-  PlatformArch: RuntimePlatformArch[];
-  PlatformInfo: {};
-  BrowserInfo: {
-    name: string;
-    vendor: string;
-    version: string;
-    buildID: string;
-  };
-  RequestUpdateCheckStatus: RuntimeRequestUpdateCheckStatus[];
-  OnInstalledReason: RuntimeOnInstalledReason[];
-  OnRestartRequiredReason: RuntimeOnRestartRequiredReason[];
-  lastError: {
+  onStartup: EventsEvent;
+  onInstalled: EventsEvent;
+  onSuspend?: EventsEvent;
+  onSuspendCanceled?: EventsEvent;
+  onUpdateAvailable: EventsEvent;
+  onBrowserUpdateAvailable?: EventsEvent;
+  onConnect: EventsEvent;
+  onConnectExternal: EventsEvent;
+  onMessage: EventsEvent;
+  onMessageExternal: EventsEvent;
+  onRestartRequired?: EventsEvent;
+  lastError?: {
     message?: string;
   };
-  id: string[];
+  id: string;
 }
 
 export type RuntimePlatformOs =
@@ -1118,15 +1430,46 @@ export type RuntimeOnRestartRequiredReason =
   | 'os_update'
   | 'periodic';
 
+export interface RuntimePort {
+  name: string;
+  disconnect: sinon.SinonStub;
+  onDisconnect: EventsEvent;
+  onMessage: EventsEvent;
+  postMessage: sinon.SinonStub;
+  sender?: RuntimeMessageSender;
+}
+
+export interface RuntimeMessageSender {
+  tab?: TabsTab;
+  frameId?: number;
+  id?: string;
+  url?: string;
+  tlsChannelId?: string;
+}
+
+export interface RuntimePlatformInfo {
+  os: RuntimePlatformOs;
+  arch: RuntimePlatformArch;
+  nacl_arch?: any;
+}
+
+export interface RuntimeBrowserInfo {
+  name: string;
+  vendor: string;
+  version: string;
+  buildID: string;
+}
+
 export interface Search {
   get: sinon.SinonStub;
   search: sinon.SinonStub;
-  SearchEngine: {
-    name: string;
-    isDefault: boolean;
-    alias?: string;
-    favIconUrl?: string;
-  };
+}
+
+export interface SearchSearchEngine {
+  name: string;
+  isDefault: boolean;
+  alias?: string;
+  favIconUrl?: string;
 }
 
 export interface Sessions {
@@ -1141,18 +1484,24 @@ export interface Sessions {
   setWindowValue: sinon.SinonStub;
   getWindowValue: sinon.SinonStub;
   removeWindowValue: sinon.SinonStub;
-  onChanged: SinonEventStub;
-  Filter: {
-    maxResults?: number;
-  };
-  Session: {
-    lastModified: number;
-  };
-  Device: {
-    info: string;
-    deviceName: string;
-  };
+  onChanged: EventsEvent;
   MAX_SESSION_RESULTS: 25;
+}
+
+export interface SessionsFilter {
+  maxResults?: number;
+}
+
+export interface SessionsSession {
+  lastModified: number;
+  tab?: TabsTab;
+  window?: WindowsWindow;
+}
+
+export interface SessionsDevice {
+  info: string;
+  deviceName: string;
+  sessions: SessionsSession[];
 }
 
 export interface SidebarAction {
@@ -1164,31 +1513,34 @@ export interface SidebarAction {
   open: sinon.SinonStub;
   close: sinon.SinonStub;
   isOpen: sinon.SinonStub;
-  ImageDataType: {};
 }
 
+export interface SidebarActionImageDataType extends ImageData {} // eslint-disable-line @typescript-eslint/no-empty-interface
+
 export interface Storage {
-  onChanged: SinonEventStub;
-  StorageChange: {
-    oldValue?: any;
-    newValue?: any;
-  };
-  StorageArea: {
-    get: sinon.SinonStub;
-    getBytesInUse?: sinon.SinonStub;
-    set: sinon.SinonStub;
-    remove: sinon.SinonStub;
-    clear: sinon.SinonStub;
-  };
-  sync: Storage['StorageArea'];
-  local: Storage['StorageArea'];
-  managed: Storage['StorageArea'];
+  onChanged: EventsEvent;
+  sync: StorageStorageArea;
+  local: StorageStorageArea;
+  managed: StorageStorageArea;
+}
+
+export interface StorageStorageChange {
+  oldValue?: any;
+  newValue?: any;
+}
+
+export interface StorageStorageArea {
+  get: sinon.SinonStub;
+  getBytesInUse?: sinon.SinonStub;
+  set: sinon.SinonStub;
+  remove: sinon.SinonStub;
+  clear: sinon.SinonStub;
 }
 
 export interface Tabs {
   get: sinon.SinonStub;
   getCurrent: sinon.SinonStub;
-  connect: sinon.SinonStub;
+  connect: () => RuntimePort;
   sendRequest?: sinon.SinonStub;
   sendMessage: sinon.SinonStub;
   getSelected?: sinon.SinonStub;
@@ -1219,80 +1571,19 @@ export interface Tabs {
   show: sinon.SinonStub;
   hide: sinon.SinonStub;
   moveInSuccession: sinon.SinonStub;
-  onCreated: SinonEventStub;
-  onUpdated: SinonEventStub;
-  onMoved: SinonEventStub;
-  onSelectionChanged?: SinonEventStub;
-  onActiveChanged?: SinonEventStub;
-  onActivated: SinonEventStub;
-  onHighlightChanged?: SinonEventStub;
-  onHighlighted: SinonEventStub;
-  onDetached: SinonEventStub;
-  onAttached: SinonEventStub;
-  onRemoved: SinonEventStub;
-  onReplaced: SinonEventStub;
-  onZoomChange: SinonEventStub;
-  MutedInfoReason: TabsMutedInfoReason[];
-  MutedInfo: {
-    muted: boolean;
-    extensionId?: string;
-  };
-  SharingState: {
-    screen?: string;
-    camera: boolean;
-    microphone: boolean;
-  };
-  Tab: {
-    id?: number;
-    index: number;
-    windowId?: number;
-    openerTabId?: number;
-    selected: boolean;
-    highlighted: boolean;
-    active: boolean;
-    pinned: boolean;
-    lastAccessed?: number;
-    audible?: boolean;
-    url?: string;
-    title?: string;
-    favIconUrl?: string;
-    status?: string;
-    discarded?: boolean;
-    incognito: boolean;
-    width?: number;
-    height?: number;
-    hidden?: boolean;
-    sessionId?: string;
-    cookieStoreId?: string;
-    isArticle?: boolean;
-    isInReaderMode?: boolean;
-    attention?: boolean;
-    successorTabId?: number;
-  };
-  ZoomSettingsMode: TabsZoomSettingsMode[];
-  ZoomSettingsScope: TabsZoomSettingsScope[];
-  ZoomSettings: {};
-  PageSettings: {
-    paperSizeUnit?: number;
-    orientation?: number;
-    shrinkToFit?: boolean;
-    showBackgroundColors?: boolean;
-    showBackgroundImages?: boolean;
-    headerLeft?: string;
-    headerCenter?: string;
-    headerRight?: string;
-    footerLeft?: string;
-    footerCenter?: string;
-    footerRight?: string;
-  };
-  TabStatus: TabsTabStatus[];
-  WindowType: TabsWindowType[];
-  UpdatePropertyName: TabsUpdatePropertyName[];
-  UpdateFilter: {
-    urls?: string[];
-    tabId?: number;
-    windowId?: number;
-  };
+  onCreated: EventsEvent;
+  onUpdated: EventsEvent;
+  onMoved: EventsEvent;
+  onSelectionChanged?: EventsEvent;
+  onActiveChanged?: EventsEvent;
+  onActivated: EventsEvent;
+  onHighlightChanged?: EventsEvent;
+  onHighlighted: EventsEvent;
+  onDetached: EventsEvent;
+  onAttached: EventsEvent;
+  onRemoved: EventsEvent;
+  onReplaced: EventsEvent;
+  onZoomChange: EventsEvent;
   TAB_ID_NONE: -1;
 }
 
@@ -1320,6 +1611,86 @@ export type TabsUpdatePropertyName =
   | 'status'
   | 'title';
 
+export interface TabsMutedInfo {
+  muted: boolean;
+  reason?: TabsMutedInfoReason;
+  extensionId?: string;
+}
+
+export interface TabsSharingState {
+  screen?: string;
+  camera: boolean;
+  microphone: boolean;
+}
+
+export interface TabsTab {
+  id?: number;
+  index: number;
+  windowId?: number;
+  openerTabId?: number;
+  selected?: boolean;
+  highlighted: boolean;
+  active: boolean;
+  pinned: boolean;
+  lastAccessed?: number;
+  audible?: boolean;
+  mutedInfo?: TabsMutedInfo;
+  url?: string;
+  title?: string;
+  favIconUrl?: string;
+  status?: string;
+  discarded?: boolean;
+  incognito: boolean;
+  width?: number;
+  height?: number;
+  hidden?: boolean;
+  sessionId?: string;
+  cookieStoreId?: string;
+  isArticle?: boolean;
+  isInReaderMode?: boolean;
+  sharingState?: TabsSharingState;
+  attention?: boolean;
+  successorTabId?: number;
+}
+
+export interface TabsZoomSettings {
+  mode?: TabsZoomSettingsMode;
+  scope?: TabsZoomSettingsScope;
+  defaultZoomFactor?: number;
+}
+
+export interface TabsPageSettings {
+  paperSizeUnit?: number;
+  paperWidth?: number;
+  paperHeight?: number;
+  orientation?: number;
+  scaling?: number;
+  shrinkToFit?: boolean;
+  showBackgroundColors?: boolean;
+  showBackgroundImages?: boolean;
+  edgeLeft?: number;
+  edgeRight?: number;
+  edgeTop?: number;
+  edgeBottom?: number;
+  marginLeft?: number;
+  marginRight?: number;
+  marginTop?: number;
+  marginBottom?: number;
+  headerLeft?: string;
+  headerCenter?: string;
+  headerRight?: string;
+  footerLeft?: string;
+  footerCenter?: string;
+  footerRight?: string;
+}
+
+export interface TabsUpdateFilter {
+  urls?: string[];
+  properties?: TabsUpdatePropertyName[];
+  tabId?: number;
+  windowId?: number;
+}
+
 export interface Telemetry {
   submitPing: sinon.SinonStub;
   canUpload: sinon.SinonStub;
@@ -1330,22 +1701,24 @@ export interface Telemetry {
   registerScalars: sinon.SinonStub;
   registerEvents: sinon.SinonStub;
   setEventRecordingEnabled: sinon.SinonStub;
-  ScalarType: TelemetryScalarType[];
-  ScalarData: {
-    keyed?: boolean;
-    record_on_release?: boolean;
-    expired?: boolean;
-  };
-  EventData: {
-    methods: string[];
-    objects: string[];
-    extra_keys: string[];
-    record_on_release?: boolean;
-    expired?: boolean;
-  };
 }
 
 export type TelemetryScalarType = 'count' | 'string' | 'boolean';
+
+export interface TelemetryScalarData {
+  kind: TelemetryScalarType;
+  keyed?: boolean;
+  record_on_release?: boolean;
+  expired?: boolean;
+}
+
+export interface TelemetryEventData {
+  methods: string[];
+  objects: string[];
+  extra_keys: string[];
+  record_on_release?: boolean;
+  expired?: boolean;
+}
 
 export interface Test {
   notifyFail: sinon.SinonStub;
@@ -1363,39 +1736,39 @@ export interface Test {
   assertLastError?: sinon.SinonStub;
   assertRejects: sinon.SinonStub;
   assertThrows: sinon.SinonStub;
-  onMessage: SinonEventStub;
+  onMessage: EventsEvent;
 }
+
+export type TestExpectedError = any;
+
+export type TestPromise = any;
 
 export interface Theme {
   getCurrent: sinon.SinonStub;
   update: sinon.SinonStub;
   reset: sinon.SinonStub;
-  onUpdated: SinonEventStub;
-  ThemeUpdateInfo: {
-    windowId?: number;
-  };
+  onUpdated: EventsEvent;
+}
+
+export interface ThemeThemeUpdateInfo {
+  theme: {};
+  windowId?: number;
 }
 
 export interface TopSites {
   get: sinon.SinonStub;
-  MostVisitedURL: {
-    url: string;
-    title?: string;
-    favicon?: string;
-    type?: string;
-  };
 }
 
-export interface Types {
-  SettingScope: TypesSettingScope[];
-  LevelOfControl: TypesLevelOfControl[];
-  Setting: {
-    get: sinon.SinonStub;
-    set: sinon.SinonStub;
-    clear: sinon.SinonStub;
-    onChange?: SinonEventStub;
-  };
+export interface TopSitesMostVisitedURL {
+  url: string;
+  title?: string;
+  favicon?: string;
+  type?: TopSitesType;
 }
+
+export type TopSitesType = 'url' | 'search';
+
+export interface Types {} // eslint-disable-line @typescript-eslint/no-empty-interface
 
 export type TypesSettingScope =
   | 'regular'
@@ -1409,20 +1782,19 @@ export type TypesLevelOfControl =
   | 'controllable_by_this_extension'
   | 'controlled_by_this_extension';
 
+export interface TypesSetting {
+  get: sinon.SinonStub;
+  set: sinon.SinonStub;
+  clear: sinon.SinonStub;
+  onChange?: EventsEvent;
+}
+
 export interface Urlbar {
-  onBehaviorRequested: SinonEventStub;
-  onQueryCanceled: SinonEventStub;
-  onResultsRequested: SinonEventStub;
-  Query: {
-    isPrivate: boolean;
-    maxResults: number;
-    searchString: string;
-  };
-  Result: {};
-  ResultType: UrlbarResultType[];
-  SourceType: UrlbarSourceType[];
-  openViewOnFocus: Types['Setting'];
-  engagementTelemetry: Types['Setting'];
+  onBehaviorRequested: EventsEvent;
+  onQueryCanceled: EventsEvent;
+  onResultsRequested: EventsEvent;
+  openViewOnFocus: TypesSetting;
+  engagementTelemetry: TypesSetting;
   contextualTip: UrlbarContextualTip;
 }
 
@@ -1436,47 +1808,66 @@ export type UrlbarSourceType =
   | 'local'
   | 'network';
 
+export interface UrlbarQuery {
+  isPrivate: boolean;
+  maxResults: number;
+  searchString: string;
+  acceptableSources: UrlbarSourceType[];
+}
+
+export interface UrlbarResult {
+  payload: {};
+  source: UrlbarSourceType;
+  type: UrlbarResultType;
+}
+
 export interface UrlbarContextualTip {
   set: sinon.SinonStub;
   remove: sinon.SinonStub;
-  onButtonClicked: SinonEventStub;
-  onLinkClicked: SinonEventStub;
-  ContextualTip: {
-    title: string;
-    buttonTitle?: string;
-    linkTitle?: string;
+  onButtonClicked: EventsEvent;
+  onLinkClicked: EventsEvent;
+  icon?: {
+    defaultIcon: any;
+    themeIcons?: ManifestThemeIcons[];
   };
+  title: string;
+  buttonTitle?: string;
+  linkTitle?: string;
 }
 
 export interface UserScripts {
   register: sinon.SinonStub;
-  UserScriptOptions: {
-    includeGlobs?: string[];
-    excludeGlobs?: string[];
-    allFrames?: boolean;
-    matchAboutBlank?: boolean;
-  };
-  RegisteredUserScript: {
-    unregister: sinon.SinonStub;
-  };
-  onBeforeScript: SinonEventStub;
+  onBeforeScript: EventsEvent;
+}
+
+export interface UserScriptsUserScriptOptions {
+  js?: ExtensionTypesExtensionFileOrCode[];
+  scriptMetadata?: ExtensionTypesPlainJSONValue;
+  matches: ManifestMatchPattern[];
+  excludeMatches?: ManifestMatchPattern[];
+  includeGlobs?: string[];
+  excludeGlobs?: string[];
+  allFrames?: boolean;
+  matchAboutBlank?: boolean;
+  runAt?: ExtensionTypesRunAt;
+}
+
+export interface UserScriptsRegisteredUserScript {
+  unregister: sinon.SinonStub;
 }
 
 export interface WebNavigation {
   getFrame: sinon.SinonStub;
   getAllFrames: sinon.SinonStub;
-  onBeforeNavigate: SinonEventStub;
-  onCommitted: SinonEventStub;
-  onDOMContentLoaded: SinonEventStub;
-  onCompleted: SinonEventStub;
-  onErrorOccurred: SinonEventStub;
-  onCreatedNavigationTarget: SinonEventStub;
-  onReferenceFragmentUpdated: SinonEventStub;
-  onTabReplaced: SinonEventStub;
-  onHistoryStateUpdated: SinonEventStub;
-  TransitionType: WebNavigationTransitionType[];
-  TransitionQualifier: WebNavigationTransitionQualifier[];
-  EventUrlFilters: {};
+  onBeforeNavigate: EventsEvent;
+  onCommitted: EventsEvent;
+  onDOMContentLoaded: EventsEvent;
+  onCompleted: EventsEvent;
+  onErrorOccurred: EventsEvent;
+  onCreatedNavigationTarget: EventsEvent;
+  onReferenceFragmentUpdated: EventsEvent;
+  onTabReplaced: EventsEvent;
+  onHistoryStateUpdated: EventsEvent;
 }
 
 export type WebNavigationTransitionType =
@@ -1498,67 +1889,23 @@ export type WebNavigationTransitionQualifier =
   | 'forward_back'
   | 'from_address_bar';
 
+export interface WebNavigationEventUrlFilters {
+  url: EventsUrlFilter[];
+}
+
 export interface WebRequest {
   handlerBehaviorChanged: sinon.SinonStub;
   filterResponseData: sinon.SinonStub;
   getSecurityInfo: sinon.SinonStub;
-  onBeforeRequest: SinonEventStub;
-  onBeforeSendHeaders: SinonEventStub;
-  onSendHeaders: SinonEventStub;
-  onHeadersReceived: SinonEventStub;
-  onAuthRequired: SinonEventStub;
-  onResponseStarted: SinonEventStub;
-  onBeforeRedirect: SinonEventStub;
-  onCompleted: SinonEventStub;
-  onErrorOccurred: SinonEventStub;
-  ResourceType: WebRequestResourceType[];
-  OnBeforeRequestOptions: WebRequestOnBeforeRequestOptions[];
-  OnBeforeSendHeadersOptions: WebRequestOnBeforeSendHeadersOptions[];
-  OnSendHeadersOptions: WebRequestOnSendHeadersOptions[];
-  OnHeadersReceivedOptions: WebRequestOnHeadersReceivedOptions[];
-  OnAuthRequiredOptions: WebRequestOnAuthRequiredOptions[];
-  OnResponseStartedOptions: WebRequestOnResponseStartedOptions[];
-  OnBeforeRedirectOptions: WebRequestOnBeforeRedirectOptions[];
-  OnCompletedOptions: WebRequestOnCompletedOptions[];
-  RequestFilter: {
-    urls: string[];
-    tabId?: number;
-    windowId?: number;
-    incognito?: boolean;
-  };
-  BlockingResponse: {
-    cancel?: boolean;
-    redirectUrl?: string;
-    upgradeToSecure?: boolean;
-  };
-  CertificateInfo: {
-    subject: string;
-    issuer: string;
-    serialNumber: string;
-    isBuiltInRoot: boolean;
-  };
-  CertificateTransparencyStatus: WebRequestCertificateTransparencyStatus[];
-  TransportWeaknessReasons: WebRequestTransportWeaknessReasons[];
-  SecurityInfo: {
-    state: string;
-    errorMessage?: string;
-    protocolVersion?: string;
-    cipherSuite?: string;
-    keaGroupName?: string;
-    signatureSchemeName?: string;
-    isDomainMismatch?: boolean;
-    isExtendedValidation?: boolean;
-    isNotValidAtThisTime?: boolean;
-    isUntrusted?: boolean;
-    hsts?: boolean;
-    hpkp?: string;
-  };
-  UploadData: {
-    bytes?: any;
-    file?: string;
-  };
-  UrlClassificationFlags: WebRequestUrlClassificationFlags[];
-  UrlClassification: {};
+  onBeforeRequest: EventsEvent;
+  onBeforeSendHeaders: EventsEvent;
+  onSendHeaders: EventsEvent;
+  onHeadersReceived: EventsEvent;
+  onAuthRequired: EventsEvent;
+  onResponseStarted: EventsEvent;
+  onBeforeRedirect: EventsEvent;
+  onCompleted: EventsEvent;
+  onErrorOccurred: EventsEvent;
   MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES: 20;
 }
 
@@ -1606,6 +1953,12 @@ export type WebRequestOnBeforeRedirectOptions = 'responseHeaders';
 
 export type WebRequestOnCompletedOptions = 'responseHeaders';
 
+export type WebRequestHttpHeaders = {
+  name: string;
+  value?: string;
+  binaryValue?: number[];
+}[];
+
 export type WebRequestCertificateTransparencyStatus =
   | 'not_applicable'
   | 'policy_compliant'
@@ -1628,6 +1981,84 @@ export type WebRequestUrlClassificationFlags =
   | 'any_strict_tracking'
   | 'any_social_tracking';
 
+export type WebRequestUrlClassificationParty = WebRequestUrlClassificationFlags[];
+
+export interface WebRequestRequestFilter {
+  urls: string[];
+  types?: WebRequestResourceType[];
+  tabId?: number;
+  windowId?: number;
+  incognito?: boolean;
+}
+
+export interface WebRequestBlockingResponse {
+  cancel?: boolean;
+  redirectUrl?: string;
+  upgradeToSecure?: boolean;
+  requestHeaders?: WebRequestHttpHeaders;
+  responseHeaders?: WebRequestHttpHeaders;
+  authCredentials?: {
+    username: string;
+    password: string;
+  };
+}
+
+export interface WebRequestCertificateInfo {
+  subject: string;
+  issuer: string;
+  validity: {
+    start: number;
+    end: number;
+  };
+  fingerprint: {
+    sha1: string;
+    sha256: string;
+  };
+  serialNumber: string;
+  isBuiltInRoot: boolean;
+  subjectPublicKeyInfoDigest: {
+    sha256: string;
+  };
+  rawDER?: number[];
+}
+
+export interface WebRequestSecurityInfo {
+  state: WebRequestState;
+  errorMessage?: string;
+  protocolVersion?: WebRequestProtocolVersion;
+  cipherSuite?: string;
+  keaGroupName?: string;
+  signatureSchemeName?: string;
+  certificates: WebRequestCertificateInfo[];
+  isDomainMismatch?: boolean;
+  isExtendedValidation?: boolean;
+  isNotValidAtThisTime?: boolean;
+  isUntrusted?: boolean;
+  certificateTransparencyStatus?: WebRequestCertificateTransparencyStatus;
+  hsts?: boolean;
+  hpkp?: string;
+  weaknessReasons?: WebRequestTransportWeaknessReasons[];
+}
+
+export type WebRequestState = 'insecure' | 'weak' | 'broken' | 'secure';
+
+export type WebRequestProtocolVersion =
+  | 'TLSv1'
+  | 'TLSv1.1'
+  | 'TLSv1.2'
+  | 'TLSv1.3'
+  | 'unknown';
+
+export interface WebRequestUploadData {
+  bytes?: any;
+  file?: string;
+}
+
+export interface WebRequestUrlClassification {
+  firstParty: WebRequestUrlClassificationParty;
+  thirdParty: WebRequestUrlClassificationParty;
+}
+
 export interface Windows {
   get: sinon.SinonStub;
   getCurrent: sinon.SinonStub;
@@ -1636,27 +2067,9 @@ export interface Windows {
   create: sinon.SinonStub;
   update: sinon.SinonStub;
   remove: sinon.SinonStub;
-  onCreated: SinonEventStub;
-  onRemoved: SinonEventStub;
-  onFocusChanged: SinonEventStub;
-  WindowType: WindowsWindowType[];
-  WindowState: WindowsWindowState[];
-  Window: {
-    id?: number;
-    focused: boolean;
-    top?: number;
-    left?: number;
-    width?: number;
-    height?: number;
-    incognito: boolean;
-    alwaysOnTop: boolean;
-    sessionId?: string;
-    title?: string;
-  };
-  CreateType: WindowsCreateType[];
-  GetInfo: {
-    populate?: boolean;
-  };
+  onCreated: EventsEvent;
+  onRemoved: EventsEvent;
+  onFocusChanged: EventsEvent;
   WINDOW_ID_NONE: -1;
   WINDOW_ID_CURRENT: -2;
 }
@@ -1677,4 +2090,23 @@ export type WindowsWindowState =
 
 export type WindowsCreateType = 'normal' | 'popup' | 'panel' | 'detached_panel';
 
-export type ContextMenus = Menus;
+export interface WindowsWindow {
+  id?: number;
+  focused: boolean;
+  top?: number;
+  left?: number;
+  width?: number;
+  height?: number;
+  tabs?: TabsTab[];
+  incognito: boolean;
+  type?: WindowsWindowType;
+  state?: WindowsWindowState;
+  alwaysOnTop: boolean;
+  sessionId?: string;
+  title?: string;
+}
+
+export interface WindowsGetInfo {
+  populate?: boolean;
+  windowTypes?: WindowsWindowType[];
+}

--- a/src/generator/helper.ts
+++ b/src/generator/helper.ts
@@ -1,3 +1,19 @@
 export function capitalize(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
+
+export function capitalizeArray(strings: string[]): string[] {
+  strings.forEach(
+    (string, index, strings) => (strings[index] = capitalize(string))
+  );
+  return strings;
+}
+
+export function isCapitalized(string: string): boolean {
+  return string.charAt(0) !== string.charAt(0).toLowerCase();
+}
+export function underscoreToCamelCase(string: string): string {
+  return string.replace(/_([a-z])/g, function(g) {
+    return g[1].toUpperCase();
+  });
+}

--- a/src/generator/typeschema.ts
+++ b/src/generator/typeschema.ts
@@ -4,38 +4,75 @@ import {
   NamespaceSchema,
   Indexable,
 } from 'webextensions-schema';
-import { capitalize } from './helper';
+import { capitalize, underscoreToCamelCase } from './helper';
 
 export type OutTypeSchema = {
   parent: Array<string>;
   childTypes: Array<string>;
+  extendsInterfaceName?: string;
+};
+
+export type OutWorking = {
+  interfaceOrTypeNames: Set<string>;
+  childObjectTypeSchemas: Array<TypeSchema>;
 };
 
 export class TypeSchemaGenerator {
+  private topLevelName: string;
   private interfaceName: string;
   private name = '';
   private out: OutTypeSchema;
+  private working: OutWorking;
 
   constructor(
+    topLevelName: string,
     interfaceName: string,
     namespace: NamespaceSchema,
-    out: OutTypeSchema
+    out: OutTypeSchema,
+    working: OutWorking
   ) {
+    this.topLevelName = topLevelName;
     this.interfaceName = interfaceName;
     this.out = out;
+    this.working = working;
+
+    this.namespaceExtends(namespace);
 
     this.typeSchemasArray(namespace.functions);
     this.typeSchemasArray(namespace.events, 'event');
-    this.typeSchemasArray(namespace.types);
+    this.typeSchemasArray(namespace.types, undefined, true);
     this.typeSchemasObject(namespace.properties);
   }
 
-  private typeSchemasArray(typeSchemas?: TypeSchema[], type?: string): void {
+  /**
+    Used when the supplied namespace is in reality a child TypeSchema
+    nested in a genuine NamespaceSchema.
+
+    The TypeSchema should be of 'object' type, and may declare
+    optional properties 'isInstanceOf' or '$import', which are handled here.
+   */
+  private namespaceExtends(namespace: NamespaceSchema): void {
+    const typeSchema = namespace as TypeSchema;
+    const extendsInterfaceName = typeSchema.isInstanceOf || typeSchema.$import;
+    if (extendsInterfaceName) {
+      const refCode = this.refCode(extendsInterfaceName);
+      this.out.extendsInterfaceName = refCode;
+    }
+  }
+
+  private typeSchemasArray(
+    typeSchemas?: TypeSchema[],
+    type?: string,
+    isInterfaceOrType?: boolean
+  ): void {
     if (!typeSchemas) return;
 
     typeSchemas.forEach(typeSchema => {
       if (type) typeSchema.type = type;
-      this.typeSchema(typeSchema);
+      const name = typeSchema.id || typeSchema.name;
+      if (name) {
+        this.typeSchema(name, typeSchema, this.out.parent, isInterfaceOrType);
+      }
     });
   }
 
@@ -46,69 +83,156 @@ export class TypeSchemaGenerator {
       if (!typeSchemas) return;
       const typeSchema = typeSchemas[typeSchemaName];
       typeSchema.name = typeSchemaName;
-      this.typeSchema(typeSchema);
+      this.typeSchema(typeSchemaName, typeSchema, this.out.parent);
     });
   }
 
-  private typeSchema(typeSchema: TypeSchema): void {
-    const name = typeSchema.id || typeSchema.name;
-    if (!name) return;
-    this.name = name;
-
-    if (typeSchema.$ref) {
-      const refParts = typeSchema.$ref.split('.');
-      if (refParts.length === 1) {
-        this.out.parent.push(
-          `${this.name}: ${this.interfaceName}["${typeSchema.$ref}"];`
-        );
-      } else {
-        const last = refParts.pop();
-        this.out.parent.push(
-          `${this.name}: ${refParts
-            .map(refPart => capitalize(refPart))
-            .join('')}["${last}"];`
-        );
-      }
-    }
-
-    if (typeSchema.type === 'string') {
-      this.out.parent.push(
-        `${this.name}: ${this.string(this.name, typeSchema.enum)};`
-      );
-    }
-
-    if (typeSchema.type === 'function') {
-      const fnOut = this.fn(typeSchema);
-      if (fnOut) this.out.parent.push(fnOut);
-    }
-
-    if (typeSchema.type === 'event') {
-      const eventOut = this.event(typeSchema);
-      if (eventOut) this.out.parent.push(eventOut);
-    }
-
-    if (typeSchema.type === 'object') {
-      this.object(typeSchema);
-    }
-
-    if (typeSchema.value) {
-      this.out.parent.push(`${typeSchema.name}: ${typeSchema.value};`);
+  private typeSchema(
+    name: string,
+    typeSchema: TypeSchema,
+    out: string[],
+    isInterfaceOrType = false
+  ): void {
+    if (isInterfaceOrType) {
+      this.interfaceOrType(name, typeSchema);
+    } else {
+      this.property(name, typeSchema, out);
     }
   }
 
-  private object(obj: TypeSchema): void {
+  private interfaceOrType(name: string, typeSchema: TypeSchema): void {
+    if (typeSchema.type === 'object') {
+      this.working.childObjectTypeSchemas.push(typeSchema);
+    } else if (typeSchema.enum) {
+      this.enum(name, typeSchema);
+    } else {
+      const childName = this.refName(name);
+      const childType = this.propertyValue(typeSchema);
+      this.out.childTypes.push(`type ${childName} = ${childType};`);
+      this.working.interfaceOrTypeNames.add(childName);
+    }
+  }
+
+  private enum(name: string, typeSchema: TypeSchema): string {
+    if (!typeSchema.enum) throw new Error('Invalid arg: missing enum property');
+    const enumName = this.refName(name);
+    const enums: Enum[] = typeSchema.enum;
+    const enumValue = enums
+      .reduce<any[]>((result, entry) => {
+        let value;
+        if (typeof entry === 'object') {
+          value = entry.name;
+        } else {
+          value = entry;
+        }
+        if (value !== undefined && value !== null) {
+          result.push(value);
+        }
+        return result;
+      }, [])
+      .join("' | '");
+
+    this.out.childTypes.push(`type ${enumName} = '${enumValue}';`);
+
+    this.working.interfaceOrTypeNames.add(enumName);
+
+    return enumName;
+  }
+
+  private property(name: string, typeSchema: TypeSchema, out: string[]): void {
+    const propertyName = this.propertyKey(
+      name,
+      typeSchema.optional || typeSchema.unsupported
+    );
+    const propertyValue = typeSchema.enum
+      ? this.enum(name, typeSchema)
+      : this.propertyValue(typeSchema);
+    if (propertyValue) {
+      out.push(`${propertyName}: ${propertyValue};`);
+    } else {
+      console.warn(`Unhandled type: ${typeSchema.type} for ${name}`);
+    }
+  }
+
+  private propertyKey(name: string, optional?: boolean): string {
+    return `${name}${optional ? '?' : ''}`;
+  }
+
+  private propertyValue(typeSchema?: TypeSchema): string | undefined {
+    if (!typeSchema) {
+      return 'any';
+    } else if (typeSchema.$ref) {
+      return this.refCode(typeSchema.$ref);
+    } else if (typeSchema.value) {
+      return `${typeSchema.value}`;
+    } else if (typeSchema.type) {
+      switch (typeSchema.type) {
+        case 'string': // Fall through
+        case 'boolean': // Fall through
+        case 'integer': // Fall through
+        case 'number': // Fall through
+        case 'any': // Fall through
+        case 'choices': // Fall through
+          let type;
+          switch (typeSchema.type) {
+            case 'integer':
+              type = 'number';
+              break;
+            case 'choices':
+              type = 'any';
+              break;
+            default:
+              type = typeSchema.type;
+          }
+          return type;
+
+        case 'array':
+          const arrayType = this.propertyValue(typeSchema.items) || 'any';
+          return `${arrayType}[]`;
+
+        case 'function':
+          return this.fnValue(typeSchema);
+
+        case 'event':
+          return this.eventValue(typeSchema);
+
+        case 'object':
+          return this.objValue(typeSchema);
+      }
+    } else if (typeSchema.choices) {
+      return 'any';
+    }
+  }
+
+  private fnValue(fn: TypeSchema): string {
+    if (fn.returns && fn.returns.$ref) {
+      return `() => ${this.refCode(fn.returns.$ref)}`;
+    } else {
+      return 'sinon.SinonStub';
+    }
+  }
+
+  private eventValue(event: TypeSchema): string {
+    return 'EventsEvent';
+  }
+
+  private objValue(obj: TypeSchema): string {
     const out: string[] = ['{'];
     if (obj.functions) {
       obj.functions.forEach(fn => {
-        const fnOut = this.fn(fn);
-        if (fnOut) out.push(fnOut);
+        if (fn.name) {
+          if (!fn.type) fn.type = 'function';
+          this.typeSchema(fn.name, fn, out);
+        }
       });
     }
 
     if (obj.events) {
       obj.events.forEach(event => {
-        const eventOut = this.event(event);
-        if (eventOut) out.push(eventOut);
+        if (event.name) {
+          if (!event.type) event.type = 'event';
+          this.typeSchema(event.name, event, out);
+        }
       });
     }
 
@@ -116,72 +240,39 @@ export class TypeSchemaGenerator {
       Object.keys(obj.properties).forEach(propertyName => {
         if (!obj.properties) return;
         const property = obj.properties[propertyName];
-        if (!property.type) return;
-
-        this.objectProperty(out, propertyName, property);
+        this.typeSchema(propertyName, property, out);
       });
     }
 
     out.push('}');
-    this.out.parent.push(`${this.name}: ${out.join('\n')};`);
+    return out.join('\n');
   }
 
-  private fn(fn: TypeSchema): string | false {
-    if (!fn.name) return false;
-    return `${fn.name}${fn.unsupported ? '?' : ''}: sinon.SinonStub;`;
+  /**
+    Used for inserting '%%namespace.somePropertyName%%' in the output. This should
+    then be processed in a later step to substitute the correct interface name.
+   */
+  private refCode(ref: string): string {
+    ref = underscoreToCamelCase(ref);
+    return `%%${this.topLevelName}.${ref}%%`;
   }
 
-  private event(event: TypeSchema): string | false {
-    if (!event.name) return false;
-    return `${event.name}${event.unsupported ? '?' : ''}: SinonEventStub;`;
-  }
-
-  private string(name: string, enums?: Enum[]): string {
-    return enums ? this.enum(name, enums) : 'string[]';
-  }
-
-  private objectProperty(
-    out: string[],
-    propertyName: string,
-    property: TypeSchema
-  ): void {
-    if (
-      property.type &&
-      ['string', 'boolean', 'integer', 'any'].includes(property.type)
-    ) {
-      const type = property.type === 'integer' ? 'number' : property.type;
-      out.push(`${this.key(propertyName, property.optional)} ${type};`);
+  /**
+    Used when inserting childTypes, which don't require any later processing step
+    and therefore can have their 'final names' calculated immediately, instead of
+    requiring a later substitution step.
+   */
+  private refName(ref: string): string {
+    ref = capitalize(underscoreToCamelCase(ref));
+    const refParts = ref.split('.');
+    let interfaceName, nestedType;
+    if (refParts.length === 1) {
+      interfaceName = capitalize(this.topLevelName);
+      nestedType = ref;
+    } else {
+      nestedType = refParts.pop();
+      interfaceName = refParts.map(refPart => capitalize(refPart)).join('');
     }
-
-    if (property.type === 'array' && property.items?.type === 'string') {
-      out.push(
-        `${this.key(propertyName, property.optional)} ${this.string(
-          propertyName,
-          property.items.enum
-        )};`
-      );
-    }
-  }
-
-  private key(name: string, optional?: boolean): string {
-    return `${name}${optional ? '?' : ''}:`;
-  }
-
-  private enum(name: string, enums: Enum[]): string {
-    const childName = `${this.interfaceName}${capitalize(name)}`;
-
-    this.out.childTypes.push(
-      `type ${childName} = '${enums
-        .map(entry => {
-          if (typeof entry === 'object') {
-            return entry.name;
-          } else {
-            return entry;
-          }
-        })
-        .join("' | '")}';`
-    );
-
-    return `${childName}[]`;
+    return `${interfaceName}${nestedType}`;
   }
 }


### PR DESCRIPTION
Re. issue: https://github.com/stoically/webextensions-api-mock/issues/1

I've rewritten the code a fair bit to handle nested interfaces and types, e.g. runtime.Port. Generation and build both run successfully.

I'd now like to test these changes against the following MAC pull request: https://github.com/mozilla/multi-account-containers/pull/1613

What I'd like to do is to remove these lines: https://github.com/mozilla/multi-account-containers/blob/30a2601d35cc0d6aae1e0a681b69a0e6a995c751/test/helper.js#L22-L24

Then, I should be able to build successfully, using my updated version of `webextensions-api-mock`. I tried this by basically copying the `dist` dir from my modified version of `webextensions-api-mock` and overwriting `node_modules/webextensions-api-mock/dist` in my clone of `multi-account-containers`. But when I `run test` in the `multi-account-containers` clone, I get the same error as before - i.e. it doesn't think the return value of `runtime.connect` has any method named `postMessage`. But my updates to `webextensions-api-mock` should have meant that `runtime.connect` now returns a `RuntimePort`. Any ideas why this isn't working?

I also noticed that `webextensions-api-mock/dist/generated/types.js` is always an empty file. Maybe it should contain all of the compiled types from `webextensions-api-mock/dist/generated/types.d.ts`?