### PR TITLE
Stubs - get 'runtime.connect()' to return a 'runtime.Port'

### DIFF
--- a/src/stub.ts
+++ b/src/stub.ts
@@ -73,7 +73,7 @@ export class BrowserBuilder {
         if (!event.name || event.type !== 'function') {
           return;
         }
-        stub[event.name] = this.event(event);
+        stub[event.name] = this.event();
       });
     }
 
@@ -113,9 +113,11 @@ export class BrowserBuilder {
     if (ref) {
       return this.schema(ref);
     } else {
-      console.warn(
-        `Ref not found '${refName}' in namespace '${this.namespaceName}'`
-      );
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          `Ref not found '${refName}' in namespace '${this.namespaceName}'`
+        );
+      }
     }
   }
 
@@ -128,8 +130,7 @@ export class BrowserBuilder {
     return stub;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private event(schema: TypeSchema): StubOut {
+  private event(): StubOut {
     return {
       addListener: this.sandbox.stub(),
       removeListener: this.sandbox.stub(),

--- a/src/stub.ts
+++ b/src/stub.ts
@@ -1,0 +1,139 @@
+import sinon from 'sinon';
+import { NamespaceSchema, TypeSchema, Indexable } from 'webextensions-schema';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type BrowserOut = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type StubOut = any;
+
+type AnySchema = {
+  $import?: string;
+  functions?: TypeSchema[];
+  properties?: Indexable<TypeSchema>;
+  events?: TypeSchema[];
+};
+
+export class BrowserBuilder {
+  public sandbox: sinon.SinonSandbox;
+  public browser: BrowserOut;
+  public aliases: Map<string, string>;
+  public types: Map<string, TypeSchema>;
+
+  private namespaceName = '';
+
+  constructor(types: Map<string, TypeSchema>) {
+    this.sandbox = sinon.createSandbox();
+    this.aliases = new Map();
+    this.browser = {
+      sinonSandbox: this.sandbox,
+    };
+    this.types = new Map(types);
+
+    // Populate typenames without namespace prefix, in cases where no match is
+    // found for lookups using fully-qualified names
+    this.types.forEach((v, k, map) => {
+      const indexOfDot = k.lastIndexOf('.');
+      if (indexOfDot !== -1) {
+        const shortKey = k.substring(indexOfDot + 1);
+        if (shortKey.length > 0 && !map.has(shortKey)) {
+          map.set(shortKey, v);
+        }
+      }
+    });
+  }
+
+  public namespace(namespace: NamespaceSchema): void {
+    this.namespaceName = namespace.namespace;
+    this.browser[this.namespaceName] = this.schema(
+      namespace,
+      this.browser[this.namespaceName]
+    );
+    this.namespaceName = '';
+  }
+
+  private schema(schema: AnySchema, stubOut?: StubOut): StubOut | undefined {
+    if (schema.$import) {
+      this.aliases.set(this.namespaceName, schema.$import);
+      return stubOut;
+    }
+
+    const stub: StubOut = stubOut || {};
+
+    if (schema.properties) {
+      Object.keys(schema.properties).forEach(propertyName => {
+        if (!schema.properties) return;
+
+        const property = schema.properties[propertyName];
+        stub[propertyName] = this.property(property);
+      });
+    }
+
+    if (schema.events) {
+      schema.events.forEach(event => {
+        if (!event.name || event.type !== 'function') {
+          return;
+        }
+        stub[event.name] = this.event(event);
+      });
+    }
+
+    if (schema.functions) {
+      schema.functions.forEach(fn => {
+        if (!fn.name || fn.type !== 'function') {
+          return;
+        }
+        stub[fn.name] = this.fn(fn);
+      });
+    }
+
+    return stub;
+  }
+
+  private property(schema: TypeSchema): StubOut | undefined {
+    if (schema.value) {
+      return schema.value;
+    } else if (schema.$ref) {
+      return this.ref(schema.$ref);
+    } else if (schema.type) {
+      switch (schema.type) {
+        case 'function':
+          return this.fn(schema);
+      }
+    }
+  }
+
+  private ref(refName: string): StubOut | undefined {
+    const fullRefName = refName.includes('.')
+      ? refName
+      : `${this.namespaceName}.${refName}`;
+    let ref = this.types.get(fullRefName);
+    if (!ref) {
+      ref = this.types.get(refName);
+    }
+    if (ref) {
+      return this.schema(ref);
+    } else {
+      console.warn(
+        `Ref not found '${refName}' in namespace '${this.namespaceName}'`
+      );
+    }
+  }
+
+  private fn(schema: TypeSchema): StubOut | undefined {
+    let stub = this.sandbox.stub();
+    if (schema.returns && schema.returns.$ref) {
+      const value = this.ref(schema.returns.$ref);
+      if (value) stub = stub.returns(value);
+    }
+    return stub;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private event(schema: TypeSchema): StubOut {
+    return {
+      addListener: this.sandbox.stub(),
+      removeListener: this.sandbox.stub(),
+      hasListener: this.sandbox.stub(),
+    };
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -15,6 +15,13 @@ describe('WebExtensionsApiMock', () => {
     );
   });
 
+  it('should return a runtime.Port from runtime.connect', () => {
+    const browser = webExtensionsApiMock();
+
+    assert(typeof browser.runtime.connect().postMessage === 'function');
+    assert(typeof browser.runtime.connect().disconnect === 'function');
+  });
+
   it('should expose the sinon sandbox', async () => {
     const browser = webExtensionsApiMock();
 


### PR DESCRIPTION
See issue: https://github.com/stoically/webextensions-api-mock/issues/1
See pr: https://github.com/stoically/webextensions-api-mock/pull/2

Fixes the problem that `browser.runtime.connect()` in a test script fails to return a `runtime.Port` with expected methods e.g. `postMessage()`, `disconnect()`.

I'm submitting this as a separate pull request from my original one, because it seems the tests work fine with just these changes relating to creating the stubs! Actually, I'm still not 100% clear what the purpose is of the generated `types.d.ts` file!

Also added some extra unit tests to cover the changes.