### PR TITLE
Stubs Reuse Bug - fix to prevent different methods reusing the same s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/sinon": "^7.5.1",
     "@typescript-eslint/eslint-plugin": "^2.8.0",
     "@typescript-eslint/parser": "^2.8.0",
+    "chai": "^4.2.0",
     "copyfiles": "^2.1.1",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.7.0",
@@ -56,6 +57,7 @@
     "mocha": "^6.2.2",
     "npm-run-all": "^4.1.5",
     "sinon": "^7.5.0",
+    "sinon-chai": "^3.3.0",
     "ts-mocha": "^6.0.0",
     "typescript": "^3.7.2"
   },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,9 @@
 import assert from 'assert';
 import webExtensionsApiMock from '../src';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+chai.should();
+chai.use(sinonChai);
 
 describe('WebExtensionsApiMock', () => {
   it('should return a browser stub', async () => {
@@ -20,6 +24,14 @@ describe('WebExtensionsApiMock', () => {
 
     assert(typeof browser.runtime.connect().postMessage === 'function');
     assert(typeof browser.runtime.connect().disconnect === 'function');
+  });
+
+  it('should not reuse sinon stubs', () => {
+    const browser = webExtensionsApiMock();
+
+    browser.runtime.connect().disconnect();
+    browser.runtime.connect().disconnect.should.have.been.called;
+    browser.runtime.connectNative().disconnect.should.not.have.been.called;
   });
 
   it('should expose the sinon sandbox', async () => {


### PR DESCRIPTION
…tub instance for their return values, leading to incorrect test results

Previously-merged PR https://github.com/stoically/webextensions-api-mock/pull/3 has a bug whereby the same stubs instance for a given type is shared between all methods that return that type. E.g. `runtime.connect()` and `runtime.connectNative()` are currently returning the same `runtime.Port` object, whereas they should each return a different instance of this type. This means if `runtime.connect().disconnect()` is called, then `sinon` will incorrectly believe that `runtime.connectNative().disconnect()` has also been called.

This PR fixes the problem and adds some unit tests to verify the code is working correctly.