### PR TITLE
Walker bugfix - handle ref-not-found differently when generating stub…

### DIFF
--- a/src/generator/namespaces-walker.ts
+++ b/src/generator/namespaces-walker.ts
@@ -81,6 +81,10 @@ export class NamespacesSchemaWalker implements SchemaWalkerDelegate {
     return `{\n${fields}\n}`;
   }
 
+  valueForInvalidRef(): SchemaWalkerValue {
+    return 'any';
+  }
+
   valueForCircularType(schemaId: SchemaId): SchemaWalkerValue {
     return Utils.typeIdWithSchemaId(schemaId).fullName;
   }

--- a/src/stub-walker.ts
+++ b/src/stub-walker.ts
@@ -78,6 +78,7 @@ export class BrowserSchemaWalker implements SchemaWalkerDelegate {
   /* eslint-disable @typescript-eslint/no-empty-function */
   finishObjectPropertyValue(): SchemaWalkerValue {}
   finishTypeValue(): SchemaWalkerValue {}
+  valueForInvalidRef(): SchemaWalkerValue {}
   valueForCircularType(): SchemaWalkerValue {}
   createEnumValue(): SchemaWalkerValue {}
   createPlainValue(): SchemaWalkerValue {}

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -31,6 +31,8 @@ export interface SchemaWalkerDelegate {
     out: SchemaWalkerValue
   ): SchemaWalkerValue;
 
+  valueForInvalidRef(schemaId: SchemaId): SchemaWalkerValue;
+
   valueForCircularType(schemaId: SchemaId): SchemaWalkerValue;
 
   finishTypeValue(
@@ -402,7 +404,7 @@ export class SchemaWalker {
       ) {
         console.warn(`Ref not found '${schemaId.name}'`);
       }
-      return 'any';
+      return this.delegate.valueForInvalidRef(schemaId);
     }
   }
 }


### PR DESCRIPTION
…s vs types

Small correction to Types PR https://github.com/stoically/webextensions-api-mock/pull/4

The current code sets the property value to `'any'` if the ref is invalid. This is ok for the `types`-generation, but doesn't make sense for the `stubs`-generation. This PR changes the `stubs`-generation code to just discard any property that has an invalid ref (i.e. `runtime.PlatformInfo.nacl_arch` in the `FIREFOX_72_0_2_RELEASE` schema)